### PR TITLE
generate_upload_token: Improve documentation

### DIFF
--- a/pydas/drivers.py
+++ b/pydas/drivers.py
@@ -931,6 +931,12 @@ class CoreDriver(BaseDriver):
         checksum allows the server to determine if the file is already in the
         asset store.
 
+        If :param:`checksum` is passed and the token returned is blank, the
+        server already has this file and there is no need to follow this
+        call with a call to `perform_upload`, as the passed in file will have
+        been added as a bitstream to the item's latest revision, creating a
+        new revision if one doesn't exist.
+
         :param token: A valid token for the user in question.
         :type token: string
         :param item_id: The id of the item in which to upload the file as a


### PR DESCRIPTION
This commit details what happen if a bitstream having the same
checksum already exists. It is consistent with the documentation
of the server side function:

   https://github.com/midasplatform/Midas/blob/fec6bda441a385d8f14642d6644e5b291177c493/core/controllers/components/ApisystemComponent.php#L332-L336