### PR TITLE
Use stream=True in download_item request

### DIFF
--- a/pydas/drivers.py
+++ b/pydas/drivers.py
@@ -705,7 +705,7 @@ class CoreDriver(BaseDriver):
         method_url = self.full_url + 'midas.item.download'
         request = requests.get(method_url,
                                params=parameters,
-                               stream=True
+                               stream=True,
                                verify=self._verify_ssl_certificate)
         filename = request.headers['content-disposition'][21:].strip('"')
         return filename, request.iter_content(chunk_size=10 * 1024)

--- a/pydas/drivers.py
+++ b/pydas/drivers.py
@@ -705,6 +705,7 @@ class CoreDriver(BaseDriver):
         method_url = self.full_url + 'midas.item.download'
         request = requests.get(method_url,
                                params=parameters,
+                               stream=True
                                verify=self._verify_ssl_certificate)
         filename = request.headers['content-disposition'][21:].strip('"')
         return filename, request.iter_content(chunk_size=10 * 1024)


### PR DESCRIPTION
`stream=True` should be used when using `iter_content`. Without this argument, the requests library will still download the entire response contents into memory.